### PR TITLE
Fix plural on Suggestions KeyboardFlags

### DIFF
--- a/dotnet/xml/Xamarin.Forms/KeyboardFlags.xml
+++ b/dotnet/xml/Xamarin.Forms/KeyboardFlags.xml
@@ -113,7 +113,7 @@
       </ReturnValue>
       <MemberValue>4</MemberValue>
       <Docs>
-        <summary>Offer suggested word completions on text that the user enters.</summary>
+        <summary>Offer suggested word completion on text that the user enters.</summary>
       </Docs>
     </Member>
   </Members>


### PR DESCRIPTION
With reference to MicrosoftDocs/xamarin-docs#397, update docs summary element of **Suggestions** [`KeyboardFlags`](xref:Xamarin.Forms.KeyboardFlags) by replacing "completions" with "completion".